### PR TITLE
fix: vscode update to use explicit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.format": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.format": "explicit"
   },
   "python.formatting.provider": "autopep8",
   "[python]": {


### PR DESCRIPTION
A recent vscode update changed some fields in setting.json from boolean values to enum values. Impacted fields have been updated to use `explicit` while functionality remains unchanged. 