### PR TITLE
Remove husky from next

### DIFF
--- a/front-end/.husky/commit-msg
+++ b/front-end/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-cd ./front-end && npx --no-install commitlint --edit 

--- a/front-end/.husky/pre-commit
+++ b/front-end/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-cd ./front-end && npx lint-staged 

--- a/front-end/.husky/prepare-commit-msg
+++ b/front-end/.husky/prepare-commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-exec < /dev/tty && cd ./front-end && npx cz --hook || true

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "eslint-config-prettier": "^8.5.0",
-    "husky": "^8.0.2",
     "prettier": "^2.7.1"
   }
 }

--- a/front-end/yarn.lock
+++ b/front-end/yarn.lock
@@ -2201,11 +2201,6 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
-husky@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.2.tgz#5816a60db02650f1f22c8b69b928fd6bcd77a236"
-  integrity sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==
-
 ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"


### PR DESCRIPTION
Husky is not currently being used when committing and pushing code. To clean up the code and to remove an unneeded dependency, I am going to remove husky from the project. 